### PR TITLE
PyPI upload of sdist package appears broken

### DIFF
--- a/binstar_client/inspect_package/pypi.py
+++ b/binstar_client/inspect_package/pypi.py
@@ -215,7 +215,7 @@ def inspect_pypi_package_sdist(filename, fileobj):
         if data is None:
             raise errors.NoMetadataError("Could not find *.egg-info/PKG-INFO file in pypi sdist")
 
-    config_items = Parser().parsestr(data).items()
+    config_items = Parser().parsestr(data.encode("UTF-8")).items()
     attrs = dict(config_items)
     name = pop_key(attrs, 'Name', None)
 
@@ -262,7 +262,7 @@ def inspect_pypi_package_egg(filename, fileobj):
     if data is None:
         raise errors.NoMetadataError("Could not find EGG-INFO/PKG-INFO file in pypi sdist")
 
-    attrs = dict(Parser().parsestr(data).items())
+    attrs = dict(Parser().parsestr(data.encode("UTF-8")).items())
 
     package_data = {'name': pop_key(attrs, 'Name'),
                     'summary': pop_key(attrs, 'Summary', None),
@@ -308,7 +308,7 @@ def inspect_pypi_package_zip(filename, fileobj):
     if data is None:
         raise errors.NoMetadataError("Could not find EGG-INFO/PKG-INFO file in pypi sdist")
 
-    attrs = dict(Parser().parsestr(data).items())
+    attrs = dict(Parser().parsestr(data.encode("UTF-8")).items())
     package_data = {'name': pop_key(attrs, 'Name'),
                     'summary': pop_key(attrs, 'Summary', None),
                     'license': pop_key(attrs, 'License', None),


### PR DESCRIPTION
10.1 of binstar is giving us the following traceback: 
```
Traceback (most recent call last):
  File "/Users/coleb/.virtualenvs/binstar_client/bin/binstar", line 9, in <module>
    load_entry_point('binstar==0.10.1', 'console_scripts', 'binstar')()
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/scripts/cli.py", line 94, in main
    description=__doc__, version=version)
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/scripts/cli.py", line 76, in binstar_main
    return args.main(args)
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/commands/upload.py", line 168, in main
    package_attrs, release_attrs, file_attrs = get_attrs(package_type, filename)
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/utils/detect.py", line 81, in get_attrs
    return detectors[package_type](filename, fileobj)
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/inspect_package/pypi.py", line 372, in inspect_pypi_package
    return inspect_pypi_package_sdist(filename, fileobj)
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/inspect_package/pypi.py", line 230, in inspect_pypi_package_sdist
    'version': pop_key(attrs, 'Version'),
  File "/Users/coleb/.virtualenvs/binstar_client/lib/python2.7/site-packages/binstar_client/inspect_package/uitls.py", line 43, in pop_key
    value = data.pop(k, *d)
KeyError: 'Version'
```
It can be chased to the fact that email.parser.Parser().parsestr() does not handle unicode cleanly, instead deciding to die silently and return nothing useful. 

Forcing a coercion to UTF-8 fixes the problem. 

Note, binstar doesn't appear to currently work with python3, so I punted on python3 compatibility. 