### PR TITLE
read new 'subdir' key from index, and default to existing way

### DIFF
--- a/binstar_client/inspect_package/conda.py
+++ b/binstar_client/inspect_package/conda.py
@@ -60,7 +60,8 @@ def inspect_conda_package(filename, fileobj):
 
     about = recipe.pop('about', {})
 
-    os_arch = arch_map[(index['platform'], index['arch'])]
+    subdir = index.get('subdir',
+                       arch_map[(index['platform'], index['arch'])])
     machine = index['arch']
     operatingsystem = os_map.get(index['platform'], index['platform'])
 
@@ -75,7 +76,7 @@ def inspect_conda_package(filename, fileobj):
                     'description': '',
                     }
     file_data = {
-                'basename': '%s/%s' % (os_arch, path.basename(filename)),
+                'basename': '%s/%s' % (subdir, path.basename(filename)),
                 'attrs':{
                         'operatingsystem': operatingsystem,
                         'machine': machine,


### PR DESCRIPTION
The way to determine the sub-directory is now read from the new 'subdir' key in the `info/index.json` file of the conda package, and still defaults to determine the value from the `platform` and `arch` keys.
This is in particular useful to support the new noarch packages which conda-build can create, see https://github.com/conda/conda-build/pull/317 (merged into master, but not yet released).
I have tested to upload a noarch package to binstar, and it works!!!  Conda is already looking for the optional `noarch` subdirectory as of conda 3.8.4.
