### PR TITLE
Upload installers

### DIFF
--- a/binstar_client/commands/upload.py
+++ b/binstar_client/commands/upload.py
@@ -74,7 +74,8 @@ def determine_package_type(filename, args):
 def get_package_name(args, package_attrs, filename, package_type):
     if args.package:
         if 'name' in package_attrs and package_attrs['name'].lower() != args.package.lower():
-            raise errors.BinstarError('Package name on the command line does not match the package name in the file "%s"' % filename)
+            msg = 'Package name on the command line " %s" does not match the package name in the file "%s"'
+            raise errors.BinstarError(msg % (args.package.lower(), package_attrs['name'].lower()))
         package_name = args.package
     else:
         if 'name' not in package_attrs:
@@ -185,6 +186,7 @@ def main(args):
 
         add_release(binstar, args, username, package_name, version, release_attrs)
 
+        binstar_package_type = file_attrs.pop('binstar_package_type', package_type)
 
         with open(filename, 'rb') as fd:
             log.info('\nUploading file %s/%s/%s/%s ... ' % (username, package_name, version, file_attrs['basename']))
@@ -194,7 +196,7 @@ def main(args):
                 continue
             try:
                 upload_info = binstar.upload(username, package_name, version, file_attrs['basename'],
-                                             fd, package_type,
+                                             fd, binstar_package_type,
                                              args.description,
                                              dependencies=file_attrs.get('dependencies'),
                                              attrs=file_attrs['attrs'],

--- a/binstar_client/inspect_package/conda_installer.py
+++ b/binstar_client/inspect_package/conda_installer.py
@@ -1,0 +1,58 @@
+import logging
+from os import path
+
+import yaml
+
+
+log = logging.getLogger(__name__)
+
+PACKAGE_TYPE = 'installer'
+
+def is_installer(filename):
+    # TODO: allow
+    if not filename.endswith('.sh'):
+        return False
+
+    with open(filename) as fd:
+        fd.readline()
+        cio_copyright = fd.readline()
+        # Copyright (c) 2012-2014 Continuum Analytics, Inc.
+        # TODO: it would be great if the installers had a unique identifier in the header
+        if "Copyright" not in cio_copyright:
+            return False
+        if "Continuum Analytics, Inc." not in cio_copyright:
+            return False
+        return True
+
+    return False
+
+def inspect_package(filename, fileobj):
+
+    lines = [fileobj.readline().strip(" #\n") for i in range(11)]
+    try:
+        installer_data = yaml.load("\n".join(lines[4:]))
+    finally:
+        log.error("Could not load installer info as YAML")
+
+
+    summary = "Conda installer for platform %s" % installer_data.pop('PLAT')
+    name = installer_data.pop('NAME')
+    version = installer_data.pop('VER')
+    attrs = installer_data
+
+    package_data = {'name': name,
+                    'summary': summary,
+                    'license': None,
+
+                    }
+    release_data = {
+                    'version': version,
+                    'description': summary,
+                    }
+    file_data = {
+                 'basename': path.basename(filename),
+                 'attrs': attrs,
+                 'binstar_package_type': 'file',
+                 }
+
+    return package_data, release_data, file_data

--- a/binstar_client/utils/__init__.py
+++ b/binstar_client/utils/__init__.py
@@ -323,11 +323,23 @@ def bool_input(prompt, default=True):
             else:
                 sys.stderr.write('please enter yes or no\n')
 
+WAIT_SECONDS = 15
 
 def upload_print_callback(args):
     start_time = time.time()
     if args.no_progress or args.log_level > logging.INFO:
-        return lambda curr, total: None
+
+        def callback(curr, total):
+            perc = 100.0 * curr / total if total else 0
+
+            if (time.time() - callback.last_output) > WAIT_SECONDS:
+                print '| %.2f%% ' % (perc),
+                sys.stdout.flush()
+                callback.last_output = time.time()
+
+        callback.last_output = time.time()
+
+        return callback
 
     def callback(curr, total):
         curr_time = time.time()

--- a/binstar_client/utils/detect.py
+++ b/binstar_client/utils/detect.py
@@ -8,6 +8,7 @@ from os import path
 import tarfile
 
 from binstar_client.inspect_package.conda import inspect_conda_package
+from binstar_client.inspect_package import conda_installer
 from binstar_client.inspect_package.pypi import inspect_pypi_package
 from binstar_client.inspect_package.r import inspect_r_package
 from binstar_client.inspect_package.ipynb import inspect_ipynb_package
@@ -20,6 +21,7 @@ detectors = {'conda':inspect_conda_package,
              'pypi': inspect_pypi_package,
              'r': inspect_r_package,
              'ipynb': inspect_ipynb_package,
+             conda_installer.PACKAGE_TYPE: conda_installer.inspect_package,
              'file': lambda filename, fileobj: ({}, {'description': ''}, {'basename': path.basename(filename), 'attrs':{}}),
              }
 
@@ -83,6 +85,8 @@ def detect_package_type(filename):
         return 'r'
     elif is_ipynb(filename):
         return 'ipynb'
+    elif conda_installer.is_installer(filename):
+        return conda_installer.PACKAGE_TYPE
     else:
         return None
 


### PR DESCRIPTION
This will allow `binstar upload` to upload linux and osx installers without any extra args. 

This will allow binstar-build to run automated installer scripts.

